### PR TITLE
Add progressive rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,21 @@ To start loading the `.splat` file, call the `load` function.
 splat.load();
 ```
 
+By default, the library will stream in the splat data and render the mesh as it arrives. You can optionally choose to load the entire splat file before rendering by setting the `progressive` option to `false`:
+
+```ts
+splat.load({progressive: false});
+```
+
+> NOTE: Streaming requires you to set up your environment to support [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer). For more information, see [Performance](#performance).
+>
+> If `SharedArrayBuffer` is not enabled, the library will load the entire splat file before rendering regardless of what is specified for the `progressive` option.
+
 You may optionally choose to provide a `THREE.LoadingManager` to track the loading progress:
 
 ```ts
 const loadingManager = new THREE.LoadingManager();
-splat.load(loadingManager);
+splat.load({loadingManager});
 ```
 
 ### Adding To Scene
@@ -207,9 +217,28 @@ To aid development, the `MaskMesh` objects are rendered with a wireframe materia
 
 ### Performance
 
-For devices that support `SharedArrayBuffer`, the sorting process within this library is significantly optimized. This feature enhances the efficiency of data handling, leading to faster rendering times and smoother user experiences.
+For devices that support `SharedArrayBuffer`, the sorting process within this library is significantly optimized.
+However, you may also be required to set additional configuration on your server to enable this feature, especially for progressive loading.
 
-To check if your device supports `SharedArrayBuffer`, please refer to <https://caniuse.com/sharedarraybuffer>
+This means you must serve the page over HTTPS & provide a valid `Cross-Origin-Opener-Policy` header. For example:
+
+```
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+Users may see these errors in the console if the above steps are not taken:
+
+```
+Uncaught (in promise) DOMException: SharedArrayBuffer will only be available in a secure context.
+```
+```
+DOMException: Failed to execute 'postMessage' on 'DedicatedWorkerGlobalScope': SharedArrayBuffer transfer requires self.crossOriginIsolated.
+```
+
+For more information, see [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements).
+
+Additionally, to check if your environment supports `SharedArrayBuffer` in the first place, please refer to <https://caniuse.com/sharedarraybuffer>. 
 
 ## How do i get .splat files?
 

--- a/cpp-sorter/worker.ts
+++ b/cpp-sorter/worker.ts
@@ -38,6 +38,11 @@ export class WasmSorter {
     return transfer(bufferToTransfer, [bufferToTransfer]);
   }
 
+  public updateGlobalBuffer(globalBuffer: Uint8Array = this.globalBuffer) {
+    this.globalBuffer = globalBuffer;
+    this.module?.HEAPU8.set(globalBuffer, this.globalBufferPtr);
+  }
+
   public returnBuffer(buffer: ArrayBuffer): void {
     this.bufferPool.returnBuffer(buffer);
   }

--- a/src/loaders/SplatLoader.ts
+++ b/src/loaders/SplatLoader.ts
@@ -6,16 +6,14 @@ export class SplatLoader extends THREE.Loader {
   }
 
   public load(url: string, onLoad?: (data: Uint8Array) => void, onProgress?: (event: ProgressEvent) => void, onError?: (event: ErrorEvent) => void): void {
-    const path = this.path === '' ? url : this.path + url;
-
-    fetch(path, {
+    fetch(this._getAbsoluteURL(url), {
       mode: 'cors',
       credentials: this.withCredentials ? 'include' : 'omit',
     })
       .then(req => {
         if (req.status !== 200) {
           if (onError) {
-            onError(new ErrorEvent('NetworkError', {message: `${req.status} Unable to load ${req.url}`}));
+            onError(this._getErrorEventForNon200Response(req));
           }
           this.manager.itemError(url);
           return;
@@ -27,7 +25,7 @@ export class SplatLoader extends THREE.Loader {
           return;
         }
 
-        const data = new Uint8Array(buffer);
+        const data = new Uint8Array(buffer, 0, this._getRowQuantisedByteLength(buffer.byteLength));
         this._processData(data, data.length, true);
 
         if (onLoad) {
@@ -38,7 +36,7 @@ export class SplatLoader extends THREE.Loader {
       })
       .catch(error => {
         if (onError) {
-          onError(new ErrorEvent('NetworkError', {message: error.message}));
+          onError(this._getErrorEventForFetchError(error));
         }
         this.manager.itemError(url);
       });
@@ -59,7 +57,139 @@ export class SplatLoader extends THREE.Loader {
     });
   }
 
+  public stream(url: string, onLoad?: (data: Uint8Array) => void, onProgress?: (event: ProgressEvent) => void, onError?: (event: ErrorEvent) => void): Promise<{data: Uint8Array; bytesRead: number}> {
+    return new Promise(resolve => {
+      fetch(this._getAbsoluteURL(url), {
+        mode: 'cors',
+        credentials: this.withCredentials ? 'include' : 'omit',
+      })
+        .then(req => {
+          if (req.status !== 200) {
+            if (onError) {
+              onError(this._getErrorEventForNon200Response(req));
+            }
+            this.manager.itemError(url);
+            return;
+          }
+
+          const {headers, body} = req;
+
+          const contentLength = Number(headers.get('Content-Length'));
+          if (!Number.isFinite(contentLength)) {
+            if (onError) {
+              onError(new ErrorEvent('NetworkError', {message: 'Cannot stream response without `Content-Length` header'}));
+            }
+            this.manager.itemError(url);
+            return;
+          }
+
+          if (!body) {
+            if (onError) {
+              onError(new ErrorEvent('NetworkError', {message: 'Empty response body'}));
+            }
+            this.manager.itemError(url);
+            return;
+          }
+
+          const reader = body.getReader();
+          const buffer = new SharedArrayBuffer(contentLength);
+          const out = {
+            data: new Uint8Array(buffer),
+            bytesRead: 0,
+          };
+
+          const _onProgress = (loaded: number, total: number) => {
+            if (onProgress) {
+              onProgress(new ProgressEvent('progress', {loaded, total}));
+            }
+          };
+
+          resolve(out);
+          _onProgress(0, contentLength);
+
+          let incompleteRowLength = 0;
+          const incompleteRow = new Uint8Array(ROW_LENGTH);
+
+          const processStream = ({done, value: currBytes}: ReadableStreamReadResult<Uint8Array>) => {
+            if (done) {
+              if (incompleteRowLength > 0) {
+                // TODO: warn the user about trailing/incomplete data
+              }
+              if (onLoad) {
+                onLoad(out.data);
+              }
+              this.manager.itemEnd(url);
+              return;
+            }
+
+            if (incompleteRowLength > 0) {
+              // write the previous incomplete row to the buffer
+              for (let i = 0; i < incompleteRowLength; i++) {
+                out.data[out.bytesRead + i] = incompleteRow[i];
+              }
+              out.bytesRead += incompleteRowLength;
+              incompleteRowLength = 0;
+              // save a write here by always zeroing out the rest of the row during write
+            }
+
+            // get the length of the complete rows
+            const currCompleteRowsByteLength = this._getRowQuantisedByteLength(out.bytesRead + currBytes.length) - out.bytesRead;
+            const currRemainingByteLength = currBytes.length - currCompleteRowsByteLength;
+
+            if (currRemainingByteLength > 0) {
+              // store the next incomplete row to be written to the next time processStream is called
+              for (let i = 0; i < currRemainingByteLength; i++) {
+                incompleteRow[i] = currBytes[currCompleteRowsByteLength + i];
+              }
+              incompleteRow.fill(0, currRemainingByteLength);
+              incompleteRowLength = currRemainingByteLength;
+            }
+
+            // get view of only the complete rows
+            const currRowBytes = currBytes.subarray(0, currCompleteRowsByteLength);
+
+            // write the complete rows to the buffer
+            out.data.set(currRowBytes, out.bytesRead);
+            out.bytesRead += currCompleteRowsByteLength;
+
+            this._processData(out.data, out.bytesRead);
+            _onProgress(out.bytesRead, contentLength);
+
+            reader.read().then(processStream);
+          };
+          reader.read().then(processStream);
+        })
+        .catch(error => {
+          if (onError) {
+            onError(this._getErrorEventForFetchError(error));
+          }
+          this.manager.itemError(url);
+        });
+
+      this.manager.itemStart(url);
+    });
+  }
+
   private _processData(data: Uint8Array, bytesRead: number, isComplete = false): void {
     this.processDataCallback?.(data, bytesRead, isComplete);
   }
+
+  private _getAbsoluteURL(url: string): string {
+    return this.path + url;
+  }
+
+  private _getErrorEventForNon200Response(req: Response): ErrorEvent {
+    return new ErrorEvent('NetworkError', {message: `${req.status} Unable to load ${req.url}`});
+  }
+
+  private _getErrorEventForFetchError(error: Error): ErrorEvent {
+    return new ErrorEvent('NetworkError', {message: error.message});
+  }
+
+  private _getRowQuantisedByteLength(rowLength: number): number {
+    return rowLength - (rowLength % ROW_LENGTH);
+  }
 }
+
+// TODO: find a way to share this constant with GaussianSplatGeometry
+const ROW_LENGTH = 3 * 4 + 3 * 4 + 4 + 4;

--- a/src/mesh/GaussianSplatMesh.ts
+++ b/src/mesh/GaussianSplatMesh.ts
@@ -20,8 +20,8 @@ export class GaussianSplatMesh extends THREE.Mesh<GaussianSplatGeometry, Gaussia
     this.rotation.x = Math.PI;
   }
 
-  public load(loadingManager?: THREE.LoadingManager) {
-    return this.geometry.load(this.url, loadingManager);
+  public load(config?: Parameters<GaussianSplatGeometry['load']>[1]) {
+    return this.geometry.load(this.url, config);
   }
 
   private _normal = new THREE.Vector3(0, 0, 1);

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -7,7 +7,7 @@ import {GaussianSplatMesh} from '../src/index';
 // import {Test} from '../src/worker_test';
 const bonsai = new URL('./bonsai.splat', import.meta.url).href;
 const splat = new GaussianSplatMesh(bonsai, 1000000);
-splat.load();
+splat.load({progressive: true});
 scene.add(splat);
 
 renderer.setAnimationLoop(animation);


### PR DESCRIPTION
Hi, thank you to the team at Zappar for this library!

## Overview

It's really hard to get a user to wait potentially 10s+ for a full splat file to download before anything shows up. This PR adds functionality to the library to progressively display splats as they are streamed from the server.

## Breaking!

This PR changes the signature of `GaussianSplatMesh.load()` to accept a config object (defined in `GaussianSplatGeometry.load(url, config)`) instead of only a `loadingManager`. 

### Alternatives

I did consider a few alternatives, but since this library just hit `0.1.0`, I figured it wouldn't be too late to add to `GaussianSplatMesh.load()` itself! (::

If the maintainers decide otherwise, please do edit/note in the review of the PR!

* A `GaussianSplatMesh.load()` & a `GaussianSplatMesh.stream()` method
* `GaussianSplatMesh.load(url, loadingManager?, progressive?)`

## Concerns/Questions

* Why is `SplatLoader` written in ES6 instead of modern JS? Considering the rest of the library is written modernly 😅. I followed that style nonetheless there, but it makes the code a little more clunky. In the future it could be changed to use the `AsyncIterable` directly from `ReadableStream` instead of recursively calling the processing function (as well as `async`/`await` hopefully xdd).

## Miscellaneous Notes

* A copy was saved between JS & WASM by removing the `trimBuffer` function that called `slice` internally. Instead, `subarray` was used to create another view to the underlying `ArrayBuffer`/`SharedArrayBuffer`
* Speaking of `SharedArrayBuffer`, it's used to write to the worker's memory from the `ReadableStream` in JS. If I'm not mistaken this introduces a requirement of headers to be included in the top-level document ([`SharedArrayBuffer` is still technically constructable without it](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements:~:text=SharedArrayBuffer%20objects%20are%20in,to%20get%20an%20instance.), so I'm not sure where the library gets its instances, or the difference between the 2 imports in `worker.ts` mean 😅). I documented this & the change in signature in the README, & added some more info regarding setting up the headers.