### PR TITLE
Disable frustum culling on `GaussianSplatMesh`

### DIFF
--- a/src/mesh/GaussianSplatMesh.ts
+++ b/src/mesh/GaussianSplatMesh.ts
@@ -13,6 +13,8 @@ export class GaussianSplatMesh extends THREE.Mesh<GaussianSplatGeometry, Gaussia
   private currentCamera?: THREE.PerspectiveCamera | THREE.Camera;
   private renderer?: THREE.WebGLRenderer;
 
+  public frustumCulled = false;
+
   constructor(private url: string, maxSplats = Infinity) {
     const material = new GaussianSplatMaterial();
     const geometry = new GaussianSplatGeometry(maxSplats);


### PR DESCRIPTION
Fixes #6

Not 100% sure why it works, but I'm assuming it's because culling only takes into account the base instance of the geometry for culling.

In the future, some sort of culling algo should probably be used, but perf after this change should remain the same since the entire model was never properly culled.